### PR TITLE
Added remotedev to awesome list

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Your contributions and suggestions are heartily welcome. =^.^=
   with MobX and TypeScript included
 * [Delorean](https://github.com/BrascoJS/delorean), A MobX-React Time Travel
   Debugger
+* [Mobx-RemoteDev](https://github.com/zalmoxisus/mobx-remotedev), MobX Time Travel Debugging using the Redux Devtools Extension
 
 ### FAQ
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,6 @@ Your contributions and suggestions are heartily welcome. =^.^=
 ### Related projects and utilities
 
 * [MobX react bindings](https://github.com/mobxjs/mobx-react)
-* [MobX remotedev: Use the Redux Devtools with MobX](https://github.com/zalmoxisus/mobx-remotedev)
 * [MobX inferno bindings](https://www.npmjs.com/package/inferno-mobx)
 * [MobX preact bindings](https://github.com/philmander/mobx-preact)
 * [mobx-react-form](https://foxhound87.github.io/mobx-react-form) Build forms


### PR DESCRIPTION
I added the github project https://github.com/zalmoxisus/mobx-remotedev to the awesome list of devtools. 

mobx-remotedev allows your MobX stores to be tracked by the redux devtools extension and allows Time Travel Debugging. 