### PR TITLE
docs(readme): mark mobx-react-devtools deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Your contributions and suggestions are heartily welcome. =^.^=
 ### Development Tools
 
 * [MobX Chrome Devtools](https://chrome.google.com/webstore/detail/mobx-developer-tools/pfgnfdagidkfgccljigdamigbcnndkod?hl=en)
-* [Mobx-React-Devtools](https://github.com/mobxjs/mobx-react-devtools)
+* [Mobx-React-Devtools (deprecated)](https://github.com/mobxjs/mobx-react-devtools)
 * [MobX Formatters](https://github.com/motion/mobx-formatters)
 * [React Ecosystem Snippets](https://marketplace.visualstudio.com/items?itemName=adamrackis.react-ecosystem-snippets)
   with MobX and TypeScript included

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Your contributions and suggestions are heartily welcome. =^.^=
 ### Development Tools
 
 * [MobX Chrome Devtools](https://chrome.google.com/webstore/detail/mobx-developer-tools/pfgnfdagidkfgccljigdamigbcnndkod?hl=en)
-* [Mobx-React-Devtools (deprecated)](https://github.com/mobxjs/mobx-react-devtools)
+* [Mobx-React-Devtools](https://github.com/mobxjs/mobx-react-devtools) - deprecated for `mobx-react@^6`, `react@^16`
+  * use MobX Chrome Devtools instead
 * [MobX Formatters](https://github.com/motion/mobx-formatters)
 * [React Ecosystem Snippets](https://marketplace.visualstudio.com/items?itemName=adamrackis.react-ecosystem-snippets)
   with MobX and TypeScript included


### PR DESCRIPTION
With the browser plugin, and mobx@6, these devTools have been marked deprecated:
https://github.com/mobxjs/mobx-react-devtools#mobx-react-devtools

From the mobx-react-devtools readMe: 
> ⚠️ Note: This package is deprecated. Use the browser plugin instead. Also note that with mobx-react@6 and higher the package should no longer be needed, see changelog ⚠️