### PR TITLE
Add mobx-keystone

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Your contributions and suggestions are heartily welcome. =^.^=
 * [mobx-spine](https://github.com/CodeYellowBV/mobx-spine) MobX with support for models, relations and an external API
 * [mmlpx](https://github.com/mmlpxjs/mmlpx) A generic mobx model layer paradigm which support di and time travelling out of box
 * [mobx-mc](https://github.com/rakenapp/mobx-mc) Backbone inspired model + collection library for Mobx
+* [mobx-keystone](https://github.com/xaviergonz/mobx-keystone) Opinionated, transactional, MobX powered state container with first-class Typescript support
 
 ### Who is using MobX?
 


### PR DESCRIPTION
[`mobx-keystone`](https://github.com/xaviergonz/mobx-keystone) is very similar to `mobx-state-tree` but offers much better Typescript support. It is mature, extremely well developed and has an active, responsive, and committed maintainer (@xaviergonz). IMHO, it is the successor of `mobx-state-tree` and should receive a lot more attention because it solves many issues of `mobx-state-tree`, is more predictable, and offers some nice additional features out of the box.