### PR TITLE
fix: update links for Vue bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,9 +481,8 @@ Your contributions and suggestions are heartily welcome. =^.^=
 * [mobx-react-inject](https://github.com/mass3ff3ct/mobx-react-inject)
   Implementation of store injection to React component with MobX, TypeScript and
   decorator metadata
-* [mobx-vue](https://github.com/mobxjs/mobx-vue) - Vue bindings for MobX
-* [vue-mobx](https://www.npmjs.com/package/vue-mobx) MobX bindings for Vue
-* [movue](https://github.com/nighca/movue) - MobX integration for Vue
+* [mobx-vue-lite](https://github.com/mobxjs/mobx-vue-lite) Lightweight Vue 3 bindings for MobX based on Composition API
+* [mobx-vue](https://github.com/mobxjs/mobx-vue) Vue 2 bindings for MobX
 * [mobx-apollo](https://github.com/sonaye/mobx-apollo) A MobX and Apollo Client
   integration utility
 * [mobx-react-intl](https://github.com/Sqooba/mobx-react-intl)


### PR DESCRIPTION
Pretty much the same as https://github.com/vuejs/awesome-vue/pull/4205, but from a bit different old state.

* Old link for [movue](https://github.com/nighca/movue) (Vue 2 bindings) is removed as it is explicitly deprecated and archived for over 2.5 years in favor of the official [mobx-vue](https://github.com/mobxjs/mobx-vue) (Vue 2 bindings).
* Old link for [vue-mobx](https://github.com/dwqs/vue-mobx) (Vue 2 bindings) is removed as it hasn't been updated for over 6.5 years, has very few downloads on NPM, Vue 2 has itself reached end-of-life, and there is the official [mobx-vue](https://github.com/mobxjs/mobx-vue) for Vue 2 bindings anyway.
* Added link for [mobx-vue-lite](https://github.com/mobxjs/mobx-vue-lite) for Vue 3 bindings and it is placed before [mobx-vue](https://github.com/mobxjs/mobx-vue) (Vue 2 bindings) as Vue 2 has reached end-of-life and is much less relevant.